### PR TITLE
clj patterns

### DIFF
--- a/src/main/re_db/util.cljc
+++ b/src/main/re_db/util.cljc
@@ -1,7 +1,7 @@
 (ns re-db.util
   (:refer-clojure :exclude [random-uuid])
   (:require [clojure.set :as set])
-  #?(:cljs (:require-macros re-db.util)))
+  #?(:cljs (:require-macros [re-db.util :as util])))
 
 (defn guard [x f] (when (f x) x))
 
@@ -72,3 +72,20 @@
                     removed (guard (set/difference s1 s2) seq)]
                 (when (or added removed)
                   [added removed]))))
+
+
+;; atom with metadata
+(util/support-clj-protocols
+ (deftype MAtom [^:volatile-mutable state metadata]
+   IDeref
+   (-deref [o] state)
+
+   IReset
+   (-reset! [o new-value]
+     (set! state new-value))
+
+   IMeta
+   (-meta [o] metadata)
+
+   IWithMeta
+   (-with-meta [o meta] (MAtom. state meta))))


### PR DESCRIPTION
This branch is for adding support for "patterns" in Clojure. 

- re-use the data structure as we use in cljs for recording pattern dependencies, eg `{e {a {v <node>}}}`
- ability to run a query while also setting up dependencies on all the patterns that should invalidate it
- registry:  `{...pattern #{queries}}`
- registry: `{query #{listeners}}`
- invalidation: loop through a list of datoms (from tx-report) and find any queries that are invalid - recompute the result & send to all listeners
- clean-up queries when last listener unlistens

TBD - figure out how similar things should work in Clojure vs ClojureScript (since Reagent doesn't work in Clojure but we probably want to keep using it in the client)