### PR TITLE
Move shadow to dev alias

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -1,4 +1,4 @@
 {:tasks {dev (do (shell "yarn install")
-                 (shell "yarn shadow-cljs -A:test:clerk:bench watch test"))
-         server (shell "yarn shadow-cljs -A:test:clerk:bench server")
+                 (shell "yarn shadow-cljs watch test"))
+         server (shell "yarn shadow-cljs server")
          bench (shell "yarn shadow-cljs release bench")}}

--- a/deps.edn
+++ b/deps.edn
@@ -10,7 +10,11 @@
         ;; Datomic
         com.datomic/datomic-pro {:mvn/version "1.0.6269"
                                  :exclusions [org.slf4j/slf4j-nop]}}
- :aliases {:test {:extra-paths ["src/test"]}
+ :aliases {:dev {thheller/shadow-cljs {:mvn/version "2.15.9"}
+                 ;; Datomic
+                 com.datomic/datomic-pro {:mvn/version "1.0.6269"
+                                          :exclusions [org.slf4j/slf4j-nop]}}
+           :test {:extra-paths ["src/test"]}
 
            :clerk {:extra-paths ["src/notebooks"]
                    :extra-deps {io.github.nextjournal/clerk

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -1,4 +1,4 @@
-{:deps true
+{:deps {:aliases [:bench :clerk :dev :test]}
  :dev-http {8008 "public"}
  :builds
  {:test


### PR DESCRIPTION
This moves shadow-cljs and datomic to the `:dev` alias so we can depend on `re-db` without pulling that in as a dep.