### PR TITLE
Fix call of entity in get*

### DIFF
--- a/src/main/re_db/read.cljc
+++ b/src/main/re_db/read.cljc
@@ -179,6 +179,8 @@
 (def ref-wrapper-entity (make-ref-wrapper entity))
 (defn root-wrapper-default [_conn _db m] m)
 
+(declare entity)
+
 (defn get* [conn db e a ref-wrapper]
   (if (= :db/id a)
     e


### PR DESCRIPTION
Fixes issues in which calls to `get*` would fail with 

```
Execution error (IllegalStateException) at re-db.read/make-ref-wrapper$fn (read.cljc:175).
Attempting to call unbound fn: #'re-db.read/entity
```