### PR TITLE
support raw :db/id as entity id

### DIFF
--- a/src/main/re_db/sync/server.clj
+++ b/src/main/re_db/sync/server.clj
@@ -12,7 +12,9 @@
 (def write-handlers
   {TaggedValue (transit/write-handler #(.-tag %) #(.-rep %))})
 
-(defn entity-pointer [id] (TaggedValue. "re-db/entity" id))
+(defn entity-pointer [id] (TaggedValue. "re-db/entity" (if (vector? id)
+                                                         id
+                                                         [:db/id id])))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Entity diffing - transacting only changes when a query updates


### PR DESCRIPTION
currently the sync system expects `:db/id` to be an upsert lookup-ref, eg. `{:db/id [:ductile/id x]}`. With this change we also support ordinary `:db/id` values.